### PR TITLE
Export environment.yml (replaces requirements.txt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,35 @@ OR
     - [Fork the repository first](https://help.github.com/articles/fork-a-repo/) to have your own copy and make changes on github!
     - feel free to [create a pull request](https://help.github.com/articles/creating-a-pull-request/) with improvements and suggestions!
 
-### Using Virtualenv and Pip
+### Option 1: With ``conda`` (recommended)
+
+Prerequisite: Must have Anaconda or [miniconda](http://conda.pydata.org/miniconda.html) installed.
+
+**Linux and OSX**:
+
+```
+conda env create -f environment.yml --name share_tutorials
+source activate share_tutorials
+```
+
+**Windows**:
+
+```
+conda env create -f environment_win.yml --name share_tutorials
+activate share_tutorials
+```
+
+### Option 2: With `virtualenv` and `pip`
 - Install requirements from ```requirements.txt``` inside a virtualenv with:
 
-    - ```(venv)$ pip install -r requirements.txt```
-
-### Miniconda
-- Install requirements from ```enviornment.yml``` with:
-    - ```conda env create -f environment.yml```
-- Linux and OSX:
-    - ```source activate share_tutorials```
-- Windows:
-    - ```activate share_tutorials```
+```
+# After activating your virtualenv
+pip install -r requirements.txt
+```
 
 
 ## Run the notebooks
+
 - Run the jupyter notebook in  a terminal with the command: ```jupyter notebook```
 - Click on the notebook you'd like to run
-- Run cells individually with the keys```shift+return```
+- Run cells individually with the `shift+return`

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,77 @@
+dependencies:
+- appnope=0.1.0=py35_0
+- backports=1.0=py35_0
+- cycler=0.10.0=py35_0
+- decorator=4.0.10=py35_0
+- entrypoints=0.2.2=py35_0
+- et_xmlfile=1.0.1=py35_0
+- freetype=2.5.5=1
+- get_terminal_size=1.0.0=py35_0
+- ipykernel=4.3.1=py35_0
+- ipywidgets=4.1.1=py35_0
+- jdcal=1.2=py35_1
+- jinja2=2.8=py35_1
+- jsonschema=2.5.1=py35_0
+- jupyter=1.0.0=py35_3
+- jupyter_client=4.3.0=py35_0
+- jupyter_console=4.1.1=py35_0
+- jupyter_core=4.1.0=py35_0
+- libpng=1.6.22=0
+- markupsafe=0.23=py35_2
+- matplotlib=1.5.1=np111py35_0
+- mistune=0.7.2=py35_1
+- mkl=11.3.3=0
+- nbconvert=4.2.0=py35_0
+- nbformat=4.0.1=py35_0
+- notebook=4.2.1=py35_0
+- numpy=1.11.1=py35_0
+- openpyxl=2.3.2=py35_0
+- openssl=1.0.2h=1
+- pandas=0.18.1=np111py35_0
+- path.py=8.2.1=py35_0
+- pexpect=4.0.1=py35_0
+- pickleshare=0.7.2=py35_0
+- pip=8.1.2=py35_0
+- ptyprocess=0.5.1=py35_0
+- pygments=2.1.3=py35_0
+- pyparsing=2.1.4=py35_0
+- pyqt=4.11.4=py35_3
+- python=3.5.2=0
+- python-dateutil=2.5.3=py35_0
+- python.app=1.2=py35_4
+- pytz=2016.4=py35_0
+- pyzmq=15.2.0=py35_1
+- qt=4.8.7=3
+- qtconsole=4.2.1=py35_0
+- readline=6.2=2
+- requests=2.10.0=py35_0
+- setuptools=23.0.0=py35_0
+- simplegeneric=0.8.1=py35_1
+- sip=4.16.9=py35_0
+- six=1.10.0=py35_0
+- sqlite=3.13.0=0
+- terminado=0.6=py35_0
+- tk=8.5.18=0
+- tornado=4.3=py35_1
+- traitlets=4.2.1=py35_0
+- wheel=0.29.0=py35_0
+- xz=5.2.2=0
+- zlib=1.2.8=3
+- pip:
+  - backports.shutil-get-terminal-size==1.0.0
+  - elasticsearch==2.3.0
+  - elasticsearch-dsl==2.1.0
+  - et-xmlfile==1.0.1
+  - furl==0.5.1
+  # TODO: Install with conda once there is an ipython 5.0.0 conda distribution
+  - ipython==5.0.0
+  - ipython-genutils==0.1.0
+  - jupyter-client==4.3.0
+  - jupyter-console==4.1.1
+  - jupyter-core==4.1.0
+  - orderedmultidict==0.7.6
+  - prompt-toolkit==1.0.3
+  # TODO: Update when next release of sharepa is on PyPI
+  - sharepa==0.2.1
+  - urllib3==1.16
+  - wcwidth==0.1.7

--- a/environment_win.yml
+++ b/environment_win.yml
@@ -1,0 +1,68 @@
+dependencies:
+- backports=1.0=py35_0
+- decorator=4.0.10=py35_0
+- entrypoints=0.2.2=py35_0
+- get_terminal_size=1.0.0=py35_0
+- ipykernel=4.3.1=py35_0
+- ipywidgets=4.1.1=py35_0
+- jinja2=2.8=py35_1
+- jpeg=8d=vc14_0
+- jsonschema=2.5.1=py35_0
+- jupyter=1.0.0=py35_3
+- jupyter_client=4.3.0=py35_0
+- jupyter_console=4.1.1=py35_0
+- jupyter_core=4.1.0=py35_0
+- libpng=1.6.22=vc14_0
+- libtiff=4.0.6=vc14_2
+- markupsafe=0.23=py35_2
+- matplotlib=1.5.1=np111py35_0
+- mistune=0.7.2=py35_0
+- mkl=11.3.3=1
+- nbconvert=4.2.0=py35_0
+- nbformat=4.0.1=py35_0
+- notebook=4.2.1=py35_0
+- numpy=1.11.1=py35_0
+- openssl=1.0.2h=vc14_0
+- pandas=0.18.1=np111py35_0
+- path.py=8.2.1=py35_0
+- pickleshare=0.7.2=py35_0
+- pip=8.1.2=py35_0
+- pygments=2.1.3=py35_0
+- pyparsing=2.1.4=py35_0
+- pyqt=4.11.4=py35_6
+- pyreadline=2.1=py35_0
+- python=3.5.2=0
+- python-dateutil=2.5.3=py35_0
+- pytz=2016.4=py35_0
+- pyzmq=15.2.0=py35_0
+- qt=4.8.7=vc14_8
+- qtconsole=4.2.1=py35_0
+- requests=2.10.0=py35_0
+- setuptools=23.0.0=py35_0
+- simplegeneric=0.8.1=py35_1
+- sip=4.16.9=py35_2
+- six=1.10.0=py35_0
+- tornado=4.3=py35_1
+- traitlets=4.2.1=py35_0
+- vs2015_runtime=14.0.25123=0
+- wheel=0.29.0=py35_0
+- zlib=1.2.8=vc14_3
+- pip:
+  - backports.shutil-get-terminal-size==1.0.0
+  - colorama==0.3.7
+  - elasticsearch==2.3.0
+  - elasticsearch-dsl==2.1.0
+  - furl==0.5.1
+  - jupyter-client==4.3.0
+  - jupyter-console==4.1.1
+  - jupyter-core==4.1.0
+  - orderedmultidict==0.7.6
+  - prompt-toolkit==1.0.3
+  # TODO: Update when next release of sharepa is on PyPI
+  - sharepa==0.2.1
+  - urllib3==1.16
+  - wcwidth==0.1.7
+  - win-unicode-console==0.5
+  # TODO: Install with conda once there is an ipython 5.0.0 conda distribution
+  - ipython==5.0.0
+  - ipython-genutils==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ requests
 furl==0.5.1
 sharepa
 openpyxl==2.3.5
-pandas>=0.18.1
+pandas==0.18.1
 jupyter==1.0.0
-matplotlib==1.4.3
+matplotlib==1.5.1
+ipython==5.0.0


### PR DESCRIPTION
Up and running with:

```
conda env create -f environment.yml --name share_tutorials
```

Or on Windows:

```
conda env create -f environment_win.yml --name share_tutorials
```

NOTE: This will install matplotlib==1.5.1 instead of matplotlib==1.4.3
We will need to verify that this version can work on MacOSX @erinspace 
